### PR TITLE
No Credit to the original source.

### DIFF
--- a/app/src/main/res/values/css.xml
+++ b/app/src/main/res/values/css.xml
@@ -102,6 +102,8 @@
         }
 	</string>
 	
+	
+//Folio's Material theme without credit?	
     <string name="MaterialTheme" translatable="false">
 * {
     -webkit-tap-highlight-color: rgb(0,0,0,0);


### PR DESCRIPTION
You're using Folio's Material Light theme without given credit to the original source. Please fix this: The original theme is found here: https://github.com/creativetrendsapps/FolioforFacebook/blob/master/app/src/main/assets/foliotheme.css