### PR TITLE
Provide build flavors to match both pachage ids

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,15 @@ android {
         versionCode 47
         versionName "3.3.0"
     }
+    
+    productFlavors {
+        labs {
+        }
+        fdroid {
+            applicationId "me.zeeroooo.materialfb"
+        }
+    }
+    
     buildTypes {
         release {
             zipAlignEnabled true


### PR DESCRIPTION
This will add two build flavors `fdroid` and `labs`, which the first one will continue to use the old package id. When building without any flavor, both are build.