### PR TITLE
Fix typo in navigation menu item settings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,7 @@
     <string name="menu_top_stories">Top stories</string>
     <string name="menu_top_stories_summary">Show &#8216;Top stories&#8217; button on navigation drawer.</string>
     <string name="menu_most_recent">Most Recent</string>
+    <string name="menu_most_recent_summary">Show &#8216;Most Recent&#8217; button on navigation drawer.</string>
     <string name="menu_friendreq">Friend Requests</string>
     <string name="menu_friendreq_summary">Show &#8216;Friend Requests&#8217; button on navigation drawer.</string>
     <string name="menu_groups">Groups</string>

--- a/app/src/main/res/xml/navigation_menu_settings.xml
+++ b/app/src/main/res/xml/navigation_menu_settings.xml
@@ -19,7 +19,7 @@
         <SwitchPreference
             android:defaultValue="false"
             android:key="nav_most_recent"
-            android:summary="@string/menu_groups_summary"
+            android:summary="@string/menu_most_recent_summary"
             android:title="@string/menu_most_recent" />
         <SwitchPreference
             android:defaultValue="false"


### PR DESCRIPTION
The "Most Recent" button option had the summary of another button.