### PR TITLE
Fix issue #206

### DIFF
--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -20,7 +20,7 @@
             android:layout_width="75dp"
             android:layout_height="75dp"
             android:layout_gravity="start"
-            android:background="@mipmap/ic_launcher_round" />
+            app:srcCompat="@mipmap/ic_launcher_round" />
 
         <TextView
             android:id="@+id/profile_name"


### PR DESCRIPTION
For some reason, using `android:background` instead of `app:srcCompat` in the ImageView in the NavigationView header makes an AdaptiveIconView, that's being used internally somewhere, freak out and throw an IllegalArgumentException. Don't exactly know why, but this fixes the crash on opening the navigation drawer on devices running API >=26.